### PR TITLE
New navigation structure for FluidSynth website

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -18,12 +18,3 @@
 
 - title: Contact
   href: /contact/
-  links:
-  - title: Bug Reports / Feature Requests
-    href: https://github.com/FluidSynth/fluidsynth/issues
-  - title: Discussion Forum
-    href: https://github.com/FluidSynth/fluidsynth/discussions
-  - title: Mailing List
-    href: http://lists.nongnu.org/mailman/listinfo/fluid-dev
-  - title: Mailing List Archives
-    href: http://lists.nongnu.org/archive/html/fluid-dev/

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -1,56 +1,26 @@
 - title: Home
   href: /
 
-- title: News
+- title: Latest News
   href: /news/
 
-- title: Screenshots
-  href: /screenshots/
-
-- title: Applications
-  href: https://github.com/FluidSynth/fluidsynth/wiki/Applications
-
-- title: Creations
-  href: https://github.com/FluidSynth/fluidsynth/wiki/MadeWithFluidSynth
+- title: Showcase
+  href: /showcase/
 
 - title: Documentation
-  href: https://github.com/FluidSynth/fluidsynth/wiki/Documentation
-  links:
-  - title: Wiki Home
-    href: https://github.com/FluidSynth/fluidsynth/wiki
-  - title: Getting Started
-    href: https://github.com/FluidSynth/fluidsynth/wiki/GettingStarted
-  - title: User Manual
-    href: https://github.com/FluidSynth/fluidsynth/wiki/UserManual
-  - title: FluidSynth Settings
-    href: https://github.com/FluidSynth/fluidsynth/wiki/FluidSettings
-  - title: About SoundFont2
-    href: https://github.com/FluidSynth/fluidsynth/wiki/SoundFont
-  - title: FluidSynth API
-    href: /api/
-  - title: FluidSynth API (legacy)
-    href: /api-1.x/
+  href: /documentation/
 
-- title: Download
-  href: https://github.com/FluidSynth/fluidsynth/releases
-
-- title: Installing
-  href: https://github.com/FluidSynth/fluidsynth/wiki/BuildingWithCMake
-  links:
-  - title: Building Source Code
-    href: https://github.com/FluidSynth/fluidsynth/wiki/BuildingWithCMake
+- title: Getting FluidSynth
+  href: /download/
 
 - title: Development
-  href: https://www.fluidsynth.org/api/
-  links:
-  - title: Bugs and Feature Requests
-    href: https://github.com/FluidSynth/fluidsynth/issues
-  - title: Git Source Code Browser
-    href: https://github.com/FluidSynth/fluidsynth
+  href: /development/
 
 - title: Contact
   href: /contact/
   links:
+  - title: Bug Reports / Feature Requests
+    href: https://github.com/FluidSynth/fluidsynth/issues
   - title: Discussion Forum
     href: https://github.com/FluidSynth/fluidsynth/discussions
   - title: Mailing List

--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -1,11 +1,3 @@
----
-layout: gallery
----
-
-# Application Screenshots
-
-FluidSynth does not have a graphical user interface, however many other programs that utilize it do, some of which are shown here.
-
 <div id="gallery-1" class="gallery galleryid-24 gallery-columns-3 gallery-size-responsive-200">
     {% for item in site.data.screenshots %}
     {% assign remainder = forloop.index | modulo: 3 %}
@@ -18,3 +10,4 @@ FluidSynth does not have a graphical user interface, however many other programs
     {% if remainder == 0 %}<br style="clear: both">{% endif %}
     {% endfor %}
 </div>
+<br style="clear: both">

--- a/contact.md
+++ b/contact.md
@@ -5,13 +5,16 @@ title: Contact Information
 # Contact Information
 
 ### GitHub
-- [GitHub Discussions](https://github.com/FluidSynth/fluidsynth/discussions) (For all questions regarding FluidSynth)
+
 - [GitHub Issues](https://github.com/FluidSynth/fluidsynth/issues) (For bug reports and feature requests only!)
+- [GitHub Discussions](https://github.com/FluidSynth/fluidsynth/discussions) (For all questions regarding FluidSynth)
 
 ### Mailing List
+
 - [fluid-dev](http://lists.nongnu.org/mailman/listinfo/fluid-dev) (For all questions regarding FluidSynth)
 
 ## Development Team
+
 - [Tom Moebert](https://github.com/derselbst) (Maintainer) – tom [d0t] mbrt [at] gmail [d0t] com
 - [Jean-Jacques Ceresa](https://github.com/jjceresa)
 - [Marcus Weseloh](https://github.com/mawe42)

--- a/development.md
+++ b/development.md
@@ -1,0 +1,16 @@
+---
+title: Development
+---
+
+# Development
+
+FluidSynth is developed on GitHub in the
+[FluidSynth/fluidsynth](https://github.com/FluidSynth/fluidsynth) repository.
+
+### Contributing
+
+If you would like to contribute to FluidSynth, please see the following links:
+ - [Contributing Guideline](https://github.com/FluidSynth/fluidsynth/blob/master/CONTRIBUTING.md)
+ - [Submit Bug Reports and Feature Requests](https://github.com/FluidSynth/fluidsynth/issues)
+ - [GitHub Disussions](https://github.com/FluidSynth/fluidsynth/discussions)
+ - [fluid-dev Mailing List](https://lists.nongnu.org/mailman/listinfo/fluid-dev)

--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,28 @@
+---
+title: Documentation
+---
+
+# User Documentation
+
+See the user documentation pages if you are looking for information about
+FluidSynth features, the usage of the bundled command-line program and
+available settings:
+
+ - [Wiki Home](https://github.com/FluidSynth/fluidsynth/wiki)
+ - [Getting Started](https://github.com/FluidSynth/fluidsynth/wiki/GettingStarted)
+ - [User Manual](https://github.com/FluidSynth/fluidsynth/wiki/UserManual)
+ - [Settings](https://github.com/FluidSynth/fluidsynth/wiki/FluidSettings)
+ - [About SoundFonts](https://github.com/FluidSynth/fluidsynth/wiki/SoundFont)
+
+
+# Developer Documentation
+
+The developer information is most useful if you want to use FluidSynth as a library in your own program or you want to extend
+FluidSynth itself:
+
+ - [Building FluidSynth with CMake](https://github.com/FluidSynth/fluidsynth/wiki/BuildingWithCMake)
+ - [Building FluidSynth for Android](https://github.com/FluidSynth/fluidsynth/wiki/BuildingForAndroid)
+ - [FluidSynth 2.x API Documentation](/api/)
+
+For legacy versions (FluidSynth 1.x), the old API documentation is also still available:
+ - [Legay API Documentation](/api-1.x/)

--- a/download.md
+++ b/download.md
@@ -1,0 +1,24 @@
+---
+title: Getting FluidSynth
+---
+
+# Getting FluidSynth
+
+### Install Packaged Version
+
+Precompiled and packaged versions of FluidSynth are available on many different platforms and distributions.
+For more Information, please see the following page:
+ - [Install Fluidsynth](https://github.com/FluidSynth/fluidsynth/wiki/Download)
+
+### Build from Source
+
+Depending on your platform and distribution, you might need to build FluidSynth yourself to use the
+most up-to-date version.
+ - [Build with CMake](https://github.com/FluidSynth/fluidsynth/wiki/BuildingWithCMake)
+ - [Build for Android](https://github.com/FluidSynth/fluidsynth/wiki/BuildingForAndroid)
+
+### Download Binary Releases
+
+For Windows and Android, you can also download and use the automatically built binary releases:
+ - [Latest Binary Releases](https://github.com/FluidSynth/fluidsynth/releases/latest)
+

--- a/showcase.md
+++ b/showcase.md
@@ -1,0 +1,24 @@
+---
+title: Showcase
+layout: gallery
+---
+
+# Showcase
+
+### Applications using FluidSynth
+
+FluidSynth is used by many different applications on a wide range of platforms. A list
+of some of the applications can be found on the Wiki page [Applications using FluidSynth](https://github.com/FluidSynth/fluidsynth/wiki/Applications).
+
+### Music and Audio created with FluidSynth
+
+FluidSynth has been used to create some original pieces of music and other audio.
+On the GitHub Wiki page [List of creations](https://github.com/FluidSynth/fluidsynth/wiki/MadeWithFluidSynth) you
+can find some examples.
+
+### Screenshots
+
+FluidSynth does not have a graphical user interface, however many other programs that utilize it do, some of which are shown here.
+
+{% include gallery.html %}
+


### PR DESCRIPTION
Following the discussion about the navigation structure and drop-down links in the menu, I've restructured the site a little. This pull request removes all but the drop-down entries on "Contact" and adds local pages with links to the GitHub wiki and sources instead.

I think this makes the page nicer to use, because you are not redirected to a completely different site via the main navigation.

@derselbst What do you think?

![Screenshot from 2020-12-14 17-29-27](https://user-images.githubusercontent.com/812001/102107815-72c91600-3e32-11eb-8a12-b74e7fbdd2b4.png)
